### PR TITLE
remove extra styles

### DIFF
--- a/public/css/display-medium-posts-public.css
+++ b/public/css/display-medium-posts-public.css
@@ -4,8 +4,7 @@
  */
   #display-medium-owl-demo .owl-item{
 	  padding-left:10px;
-        padding-right:10px;
-	  border-right: 1px solid #ddd;
+    padding-right:10px;
 	  padding-top:10px;
 	  padding-bottom:10px;
 	}
@@ -14,7 +13,4 @@
 	  max-width: 100%;
 	  height: auto;
 	  max-height: 240px;
-	}
-	#display-medium-owl-demo .details-title {
-		border-bottom: 1px solid #212121;
 	}


### PR DESCRIPTION
I generally prefer to add appropriate styles in a theme or css customizer rather than have to undo plugin-supplied styles. So I've removed the borders which may or may not be needed depending on the theme.

Obviously this would break existing installations and may not be preferred for all users so I leave it for consideration.