### PR TITLE
show image as div background to ensure consistent sizing

### DIFF
--- a/display-medium-posts.php
+++ b/display-medium-posts.php
@@ -171,12 +171,16 @@ run_display_medium_posts();
 			<?php foreach($items as $item) { ?>
 		  	<div class="display-medium-item">
 		  		<a href="<?php echo $item['url']; ?>" target="_blank">
-		  			<img data-src="<?php echo $item['image']; ?>" class="lazyOwl">
+		  			
 		  			<?php 
 		  				if($list)
 		  				{
 		  					echo '<img src="'.$item['image'].'" class="display-medium-img">';
-		  				}
+						}
+						else
+						{
+							echo '<div data-src="'.$item['image'].'" class="lazyOwl medium-image"></div>';
+						}
 		  			?>
 		  			<p class="display-medium-title details-title"><?php echo $item['title']; ?></p>
 		  		</a>

--- a/public/css/display-medium-posts-public.css
+++ b/public/css/display-medium-posts-public.css
@@ -13,7 +13,14 @@
 	  display: block;
 	  max-width: 100%;
 	  height: auto;
-	  max-height: 240px;
+	  max-height: 200px;
+	}
+	#display-medium-owl-demo .medium-image{
+	  display: block;
+	  max-width: 100%;
+		height: 200px;
+		background-size: cover;
+		background-position: center;
 	}
 	#display-medium-owl-demo .details-title {
 		border-bottom: 1px solid #212121;


### PR DESCRIPTION
For the carousel, I wanted to have all images consistently sized. A common way of doing this is to set the image as a background on a block object with uniform height, and set the `background-size` and `background-position` . Thus regardless of image size or orientation we have a consistent appearance across the screen.

The list view is not affected in this PR - I don't plan to use it and I'm not sure what would be desirable in that case.